### PR TITLE
迁移torrent搜索至Meilisearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 | 时间 | 目的 | 介绍 | 相关commit或pr |
 |:---:|:---:|:---:|:---:|
+| 2023.03.12 | 迁移搜索至Meilisearch | <https://blog.rhilip.info/archives/1275/> | <https://github.com/Rhilip/NexusPHP/pull/6> |
 | 2022.03.10 | 优化`files`表 | <https://github.com/xiaomlove/nexusphp/issues/27> |  |
 | 2022.03.10 | 屏蔽Bittorrent v2 | ... | <https://github.com/Rhilip/NexusPHP/pull/5> |
 | 2020.05.30 | 修复前一commit错误，合并一些更新 | ... | <https://github.com/Rhilip/NexusPHP/pull/3> |

--- a/classes/Components/Meili.php
+++ b/classes/Components/Meili.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace NexusPHP\Components;
+use Meilisearch\Client;
+
+class Meili
+{
+    protected static $_meiliSearch;
+
+    /**
+     * @return mixed
+     */
+    public static function getMeiliSearch()
+    {
+
+        global $meilisearch_host, $meilisearch_key;
+
+        if (self::$_meiliSearch === null) {
+            self::$_meiliSearch = new Client($meilisearch_host, $meilisearch_key);
+        }
+
+        return self::$_meiliSearch;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,17 @@
     "ext-redis": "*",
     "ext-mysqli": "*",
     "rhilip/bencode": "^2.0",
-    "phpmailer/phpmailer": "^6.1"
+    "phpmailer/phpmailer": "^6.1",
+    "meilisearch/meilisearch-php": "^1.0"
   },
   "autoload": {
     "psr-4": {
       "NexusPHP\\": "classes/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": true
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,538 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb249c8bd9ee8a8125e8cde667555598",
+    "content-hash": "fcfa8e85160262d5d026e3ec0cd3635f",
     "packages": [
+        {
+            "name": "clue/stream-filter",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/stream-filter.git",
+                "reference": "d6169430c7731d8509da7aecd0af756a5747b78e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/stream-filter/zipball/d6169430c7731d8509da7aecd0af756a5747b78e",
+                "reference": "d6169430c7731d8509da7aecd0af756a5747b78e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "Clue\\StreamFilter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "A simple and modern approach to stream filtering in PHP",
+            "homepage": "https://github.com/clue/php-stream-filter",
+            "keywords": [
+                "bucket brigade",
+                "callback",
+                "filter",
+                "php_user_filter",
+                "stream",
+                "stream_filter_append",
+                "stream_filter_register"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/stream-filter/issues",
+                "source": "https://github.com/clue/stream-filter/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-21T13:15:14+00:00"
+        },
+        {
+            "name": "meilisearch/meilisearch-php",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/meilisearch/meilisearch-php.git",
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
+                "reference": "11f12a2e36a6c616ffa5c6ed32272f8c870aaf69",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "php-http/client-common": "^2.0",
+                "php-http/discovery": "^1.7",
+                "php-http/httplug": "^2.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "guzzlehttp/guzzle": "^7.1",
+                "http-interop/http-factory-guzzle": "^1.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "1.9.14",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^9.5"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Use Guzzle ^7 as HTTP client",
+                "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MeiliSearch\\": "src/",
+                    "Meilisearch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Clementine Urquizar",
+                    "email": "clementine@meilisearch.com"
+                }
+            ],
+            "description": "PHP wrapper for the Meilisearch API",
+            "keywords": [
+                "api",
+                "client",
+                "instant",
+                "meilisearch",
+                "php",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/meilisearch/meilisearch-php/issues",
+                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.0.0"
+            },
+            "time": "2023-02-06T13:25:35+00:00"
+        },
+        {
+            "name": "php-http/client-common",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/client-common.git",
+                "reference": "45db684cd4e186dcdc2b9c06b22970fe123796c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/45db684cd4e186dcdc2b9c06b22970fe123796c0",
+                "reference": "45db684cd4e186dcdc2b9c06b22970fe123796c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/httplug": "^2.0",
+                "php-http/message": "^1.6",
+                "php-http/message-factory": "^1.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.17"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "^1.1",
+                "guzzlehttp/psr7": "^1.4",
+                "nyholm/psr7": "^1.2",
+                "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
+                "phpspec/prophecy": "^1.10.2",
+                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.3"
+            },
+            "suggest": {
+                "ext-json": "To detect JSON responses with the ContentTypePlugin",
+                "ext-libxml": "To detect XML responses with the ContentTypePlugin",
+                "php-http/cache-plugin": "PSR-6 Cache plugin",
+                "php-http/logger-plugin": "PSR-3 Logger plugin",
+                "php-http/stopwatch-plugin": "Symfony Stopwatch plugin"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\Common\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Common HTTP Client implementations and tools for HTTPlug",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "common",
+                "http",
+                "httplug"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/client-common/issues",
+                "source": "https://github.com/php-http/client-common/tree/2.6.0"
+            },
+            "time": "2022-09-29T09:59:43+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.15.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "5cc428320191ac1d0b6520034c2dc0698628ced5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/5cc428320191ac1d0b6520034c2dc0698628ced5",
+                "reference": "5cc428320191ac1d0b6520034c2dc0698628ced5",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "symfony/phpunit-bridge": "^6.2"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.15.2"
+            },
+            "time": "2023-02-11T08:28:41+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "f640739f80dfa1152533976e3c112477f69274eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/f640739f80dfa1152533976e3c112477f69274eb",
+                "reference": "f640739f80dfa1152533976e3c112477f69274eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/promise": "^1.1",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1",
+                "phpspec/phpspec": "^5.1 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/httplug/issues",
+                "source": "https://github.com/php-http/httplug/tree/2.3.0"
+            },
+            "time": "2022-02-21T09:52:22+00:00"
+        },
+        {
+            "name": "php-http/message",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message.git",
+                "reference": "7886e647a30a966a1a8d1dad1845b71ca8678361"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message/zipball/7886e647a30a966a1a8d1dad1845b71ca8678361",
+                "reference": "7886e647a30a966a1a8d1dad1845b71ca8678361",
+                "shasum": ""
+            },
+            "require": {
+                "clue/stream-filter": "^1.5",
+                "php": "^7.1 || ^8.0",
+                "php-http/message-factory": "^1.0.2",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.6",
+                "ext-zlib": "*",
+                "guzzlehttp/psr7": "^1.0",
+                "laminas/laminas-diactoros": "^2.0",
+                "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
+                "slim/slim": "^3.0"
+            },
+            "suggest": {
+                "ext-zlib": "Used with compressor/decompressor streams",
+                "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
+                "laminas/laminas-diactoros": "Used with Diactoros Factories",
+                "slim/slim": "Used with Slim Framework PSR-7 implementation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/filters.php"
+                ],
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTP Message related tools",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/message/issues",
+                "source": "https://github.com/php-http/message/tree/1.13.0"
+            },
+            "time": "2022-02-11T13:41:14+00:00"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/message-factory/issues",
+                "source": "https://github.com/php-http/message-factory/tree/master"
+            },
+            "time": "2015-12-19T14:08:53+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
+                "phpspec/phpspec": "^5.1.2 || ^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/promise/issues",
+                "source": "https://github.com/php-http/promise/tree/1.1.0"
+            },
+            "time": "2020-07-07T09:29:14+00:00"
+        },
         {
             "name": "phpmailer/phpmailer",
             "version": "v6.6.0",
@@ -85,6 +615,166 @@
             "time": "2022-02-28T15:31:21+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "rhilip/bencode",
             "version": "v2.1.1",
             "source": {
@@ -134,6 +824,223 @@
                 "source": "https://github.com/Rhilip/Bencode/tree/v2.1.1"
             },
             "time": "2022-03-29T11:33:16+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-01T10:25:55+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v6.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/aa0e85b53bbb2b4951960efd61d295907eacd629",
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v6.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-02-14T08:44:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
         }
     ],
     "packages-dev": [],
@@ -148,5 +1055,5 @@
         "ext-mysqli": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/include/cleanup.php
+++ b/include/cleanup.php
@@ -89,12 +89,6 @@ function docleanup($forceAll = 0, $printProgress = false)
         \NexusPHP\Components\Database::query("UPDATE avps SET value_u = ".\NexusPHP\Components\Database::escape($now)." WHERE arg='lastcleantime2'") or sqlerr(__FILE__, __LINE__);
     }
 
-    //2.5.update torrents' visibility
-    $deadtime = deadtime() - $max_dead_torrent_time;
-    \NexusPHP\Components\Database::query("UPDATE torrents SET visible='no' WHERE visible='yes' AND last_action < FROM_UNIXTIME($deadtime) AND seeders=0") or sqlerr(__FILE__, __LINE__);
-    if ($printProgress) {
-        printProgress("update torrents' visibility");
-    }
     //Priority Class 3: cleanup every 60 mins
     $res = \NexusPHP\Components\Database::query("SELECT value_u FROM avps WHERE arg = 'lastcleantime3'");
     $row = mysqli_fetch_array($res);
@@ -107,6 +101,112 @@ function docleanup($forceAll = 0, $printProgress = false)
         return 'Cleanup ends at Priority Class 2';
     } else {
         \NexusPHP\Components\Database::query("UPDATE avps SET value_u = ".\NexusPHP\Components\Database::escape($now)." WHERE arg='lastcleantime3'") or sqlerr(__FILE__, __LINE__);
+    }
+
+    //2.5.update torrents' visibility
+    $deadtime = deadtime() - $max_dead_torrent_time;
+    \NexusPHP\Components\Database::query("UPDATE torrents SET visible='no' WHERE visible='yes' AND last_action < FROM_UNIXTIME($deadtime) AND seeders=0") or sqlerr(__FILE__, __LINE__);
+    if ($printProgress) {
+        printProgress("update torrents' visibility");
+    }
+
+    //15.cleanup torrents
+    //Start: expire torrent promotion
+    function torrent_promotion_expire($days, $type = 2, $targettype = 1)
+    {
+        $secs = (int)($days * 86400); //XX days
+        $dt = \NexusPHP\Components\Database::escape(date("Y-m-d H:i:s", (TIMENOW - ($secs))));
+        $res = \NexusPHP\Components\Database::query("SELECT id, name FROM torrents WHERE added < $dt AND sp_state = ".\NexusPHP\Components\Database::escape($type).' AND promotion_time_type=0') or sqlerr(__FILE__, __LINE__);
+        switch ($targettype) {
+            case 1: //normal
+            {
+                $sp_state = 1;
+                $become = "normal";
+                break;
+            }
+            case 2: //Free
+            {
+                $sp_state = 2;
+                $become = "Free";
+                break;
+            }
+            case 3: //2X
+            {
+                $sp_state = 3;
+                $become = "2X";
+                break;
+            }
+            case 4: //2X Free
+            {
+                $sp_state = 4;
+                $become = "2X Free";
+                break;
+            }
+            case 5: //Half Leech
+            {
+                $sp_state = 5;
+                $become = "50%";
+                break;
+            }
+            case 6: //2X Half Leech
+            {
+                $sp_state = 6;
+                $become = "2X 50%";
+                break;
+            }
+            default: //normal
+            {
+                $sp_state = 1;
+                $become = "normal";
+                break;
+            }
+        }
+        while ($arr = mysqli_fetch_assoc($res)) {
+            \NexusPHP\Components\Database::query("UPDATE torrents SET sp_state = ".\NexusPHP\Components\Database::escape($sp_state)." WHERE id=$arr[id]") or sqlerr(__FILE__, __LINE__);
+            if ($sp_state == 1) {
+                write_log("Torrent $arr[id] ($arr[name]) is no longer on promotion (time expired)", 'normal');
+            } else {
+                write_log("Promotion type for torrent $arr[id] ($arr[name]) is changed to ".$become." (time expired)", 'normal');
+            }
+        }
+    }
+    if ($expirehalfleech_torrent) {
+        torrent_promotion_expire($expirehalfleech_torrent, 5, $halfleechbecome_torrent);
+    }
+    if ($expirefree_torrent) {
+        torrent_promotion_expire($expirefree_torrent, 2, $freebecome_torrent);
+    }
+    if ($expiretwoup_torrent) {
+        torrent_promotion_expire($expiretwoup_torrent, 3, $twoupbecome_torrent);
+    }
+    if ($expiretwoupfree_torrent) {
+        torrent_promotion_expire($expiretwoupfree_torrent, 4, $twoupfreebecome_torrent);
+    }
+    if ($expiretwouphalfleech_torrent) {
+        torrent_promotion_expire($expiretwouphalfleech_torrent, 6, $twouphalfleechbecome_torrent);
+    }
+    if ($expirethirtypercentleech_torrent) {
+        torrent_promotion_expire($expirethirtypercentleech_torrent, 7, $thirtypercentleechbecome_torrent);
+    }
+    if ($expirenormal_torrent) {
+        torrent_promotion_expire($expirenormal_torrent, 1, $normalbecome_torrent);
+    }
+
+    //expire individual torrent promotion
+    \NexusPHP\Components\Database::query("UPDATE torrents SET sp_state = 1, promotion_time_type=0, promotion_until='0000-00-00 00:00:00' WHERE promotion_time_type=2 AND promotion_until < ".\NexusPHP\Components\Database::escape(date("Y-m-d H:i:s", TIMENOW))) or sqlerr(__FILE__, __LINE__);
+
+    //End: expire torrent promotion
+    if ($printProgress) {
+        printProgress("expire torrent promotion");
+    }
+    //automatically pick hot
+    if ($hotdays_torrent) {
+        $secs = (int)($hotdays_torrent * 86400); //XX days
+        $dt = \NexusPHP\Components\Database::escape(date("Y-m-d H:i:s", (TIMENOW - ($secs))));
+        \NexusPHP\Components\Database::query("UPDATE torrents SET picktype = 'hot' WHERE added > $dt AND picktype = 'normal' AND seeders > ".\NexusPHP\Components\Database::escape($hotseeder_torrent)) or sqlerr(__FILE__, __LINE__);
+    }
+    if ($printProgress) {
+        printProgress("automatically pick hot");
     }
 
     //4.update count of seeders, leechers, comments for torrents
@@ -146,8 +246,15 @@ function docleanup($forceAll = 0, $printProgress = false)
             \NexusPHP\Components\Database::query("UPDATE torrents SET " . implode(",", $update) . " WHERE id = $id") or sqlerr(__FILE__, __LINE__);
         }
     }
+
+    \NexusPHP\Components\Database::exec("UPDATE `torrents` SET visible = 'yes' WHERE visible = 'no' and seeders != 0");
     if ($printProgress) {
         printProgress("update count of seeders, leechers, comments for torrents");
+    }
+
+    full_sync_mysql2meili();
+    if ($printProgress) {
+        printProgress("full sync torrents table from mysql to meilisearch");
     }
 
     //set no-advertisement-by-bonus time out
@@ -204,105 +311,6 @@ function docleanup($forceAll = 0, $printProgress = false)
     }
     if ($printProgress) {
         printProgress("delete offers if not uploaded after being voted on for some time.");
-    }
-
-    //15.cleanup torrents
-    //Start: expire torrent promotion
-    function torrent_promotion_expire($days, $type = 2, $targettype = 1)
-    {
-        $secs = (int)($days * 86400); //XX days
-        $dt = \NexusPHP\Components\Database::escape(date("Y-m-d H:i:s", (TIMENOW - ($secs))));
-        $res = \NexusPHP\Components\Database::query("SELECT id, name FROM torrents WHERE added < $dt AND sp_state = ".\NexusPHP\Components\Database::escape($type).' AND promotion_time_type=0') or sqlerr(__FILE__, __LINE__);
-        switch ($targettype) {
-        case 1: //normal
-        {
-            $sp_state = 1;
-            $become = "normal";
-            break;
-        }
-        case 2: //Free
-        {
-            $sp_state = 2;
-            $become = "Free";
-            break;
-        }
-        case 3: //2X
-        {
-            $sp_state = 3;
-            $become = "2X";
-            break;
-        }
-        case 4: //2X Free
-        {
-            $sp_state = 4;
-            $become = "2X Free";
-            break;
-        }
-        case 5: //Half Leech
-        {
-            $sp_state = 5;
-            $become = "50%";
-            break;
-        }
-        case 6: //2X Half Leech
-        {
-            $sp_state = 6;
-            $become = "2X 50%";
-            break;
-        }
-        default: //normal
-        {
-            $sp_state = 1;
-            $become = "normal";
-            break;
-        }
-    }
-        while ($arr = mysqli_fetch_assoc($res)) {
-            \NexusPHP\Components\Database::query("UPDATE torrents SET sp_state = ".\NexusPHP\Components\Database::escape($sp_state)." WHERE id=$arr[id]") or sqlerr(__FILE__, __LINE__);
-            if ($sp_state == 1) {
-                write_log("Torrent $arr[id] ($arr[name]) is no longer on promotion (time expired)", 'normal');
-            } else {
-                write_log("Promotion type for torrent $arr[id] ($arr[name]) is changed to ".$become." (time expired)", 'normal');
-            }
-        }
-    }
-    if ($expirehalfleech_torrent) {
-        torrent_promotion_expire($expirehalfleech_torrent, 5, $halfleechbecome_torrent);
-    }
-    if ($expirefree_torrent) {
-        torrent_promotion_expire($expirefree_torrent, 2, $freebecome_torrent);
-    }
-    if ($expiretwoup_torrent) {
-        torrent_promotion_expire($expiretwoup_torrent, 3, $twoupbecome_torrent);
-    }
-    if ($expiretwoupfree_torrent) {
-        torrent_promotion_expire($expiretwoupfree_torrent, 4, $twoupfreebecome_torrent);
-    }
-    if ($expiretwouphalfleech_torrent) {
-        torrent_promotion_expire($expiretwouphalfleech_torrent, 6, $twouphalfleechbecome_torrent);
-    }
-    if ($expirethirtypercentleech_torrent) {
-        torrent_promotion_expire($expirethirtypercentleech_torrent, 7, $thirtypercentleechbecome_torrent);
-    }
-    if ($expirenormal_torrent) {
-        torrent_promotion_expire($expirenormal_torrent, 1, $normalbecome_torrent);
-    }
-
-    //expire individual torrent promotion
-    \NexusPHP\Components\Database::query("UPDATE torrents SET sp_state = 1, promotion_time_type=0, promotion_until='0000-00-00 00:00:00' WHERE promotion_time_type=2 AND promotion_until < ".\NexusPHP\Components\Database::escape(date("Y-m-d H:i:s", TIMENOW))) or sqlerr(__FILE__, __LINE__);
-
-    //End: expire torrent promotion
-    if ($printProgress) {
-        printProgress("expire torrent promotion");
-    }
-    //automatically pick hot
-    if ($hotdays_torrent) {
-        $secs = (int)($hotdays_torrent * 86400); //XX days
-        $dt = \NexusPHP\Components\Database::escape(date("Y-m-d H:i:s", (TIMENOW - ($secs))));
-        \NexusPHP\Components\Database::query("UPDATE torrents SET picktype = 'hot' WHERE added > $dt AND picktype = 'normal' AND seeders > ".\NexusPHP\Components\Database::escape($hotseeder_torrent)) or sqlerr(__FILE__, __LINE__);
-    }
-    if ($printProgress) {
-        printProgress("automatically pick hot");
     }
 
     //Priority Class 4: cleanup every 24 hours
@@ -588,10 +596,10 @@ function docleanup($forceAll = 0, $printProgress = false)
         //die("s" . $arr['id']);
         $res2 = \NexusPHP\Components\Database::query("SELECT SUM(seedtime) as st, SUM(leechtime) as lt FROM snatched where userid = " . $arr['id'] . " LIMIT 1") or sqlerr(__FILE__, __LINE__);
         $arr2 = mysqli_fetch_assoc($res2) or sqlerr(__FILE__, __LINE__);
-        
+
         //die("ss" . $arr2['st']);
         //die("sss" . "UPDATE users SET seedtime = " . $arr2['st'] . ", leechtime = " . $arr2['lt'] . " WHERE id = " . $arr['id']);
-        
+
         \NexusPHP\Components\Database::query("UPDATE users SET seedtime = " . intval($arr2['st']) . ", leechtime = " . intval($arr2['lt']) . " WHERE id = " . $arr['id']) or sqlerr(__FILE__, __LINE__);
     }
     if ($printProgress) {

--- a/include/config.php
+++ b/include/config.php
@@ -5,61 +5,11 @@ if (!defined('IN_TRACKER')) {
 }
 
 $CONFIGURATIONS = array('ACCOUNT', 'ADVERTISEMENT', 'ATTACHMENT', 'AUTHORITY', 'BASIC', 'BONUS', 'CODE', 'MAIN', 'SECURITY', 'SMTP', 'TORRENT', 'TWEAK');
-function ReadConfig($configname = null)
-{
-    global $CONFIGURATIONS;
-    if ($configname) {
-        $configname = basename($configname);
-        $tmp = oldReadConfig($configname);
-        WriteConfig($configname, $tmp);
-        @unlink('./config/'.$configname);
-        return $tmp;
-    } else {
-        foreach ($CONFIGURATIONS as $CONFIGURATION) {
-            $GLOBALS[$CONFIGURATION] = ReadConfig($CONFIGURATION);
-        }
-    }
-}
-
-function oldReadConfig($configname)
-{
-    if (strstr($configname, ',')) {
-        $configlist = explode(',', $configname);
-        foreach ($configlist as $key=>$configname) {
-            ReadConfig(trim($configname));
-        }
-    } else {
-        $configname = basename($configname);
-        $path = './config/'.$configname;
-        if (!file_exists($path)) {
-            die("Error! File <b>".htmlspecialchars($configname)."</b> doesn't exist!</font><br /><font color=blue>Before the setup starts, please ensure that you have properly configured file and directory access permissions. Please see below.</font><br /><br />chmod 777 config/<br />chmod 777 config/".$configname);
-        }
-
-        $fp = fopen($path, 'r');
-        $content = '';
-        while (!feof($fp)) {
-            $content .= fread($fp, 102400);
-        }
-        fclose($fp);
-
-        if (empty($content)) {
-            return array();
-        }
-        $tmp = @unserialize($content);
-
-        if (empty($tmp)) {
-            die("Error! <font color=red>Cannot read configuration file <b>".htmlspecialchars($configname)."</b></font><br /><font color=blue>Before the setup starts, please ensure that you have properly configured file and directory access permissions. For *nix system, please see below.</font><br />chmod 777 config <br />chmod 777 config/".$configname."<br /><br /> If access permission is alright, perhaps there's some misconfiguration or the configuration file is corrupted. Please check config/".$configname);
-        }
-        $GLOBALS[$configname] = $tmp;
-        return $tmp;
-    }
-}
-
 
 if (file_exists('config/allconfig.php')) {
     require('config/allconfig.php');
 } else {
-    ReadConfig();
+    die("Error! <font color=red>Cannot read configuration file </font>");
 }
 
 $SITENAME = $BASIC['SITENAME'];
@@ -70,7 +20,8 @@ $mysql_host = $BASIC['mysql_host'];
 $mysql_user = $BASIC['mysql_user'];
 $mysql_pass = $BASIC['mysql_pass'];
 $mysql_db = $BASIC['mysql_db'];
-
+$meilisearch_host = $BASIC['meilisearch_host'] ?? 'http://localhost:7700';
+$meilisearch_key = $BASIC['meilisearch_key'];
 
 $SITE_ONLINE = $MAIN['site_online'];
 $max_torrent_size = $MAIN['max_torrent_size'];

--- a/settings.php
+++ b/settings.php
@@ -53,7 +53,7 @@ if ($action == 'savesettings_main') {	// save main
     go_back();
 } elseif ($action == 'savesettings_basic') { 	// save basic
     stdhead($lang_settings['head_save_basic_settings']);
-    $validConfig = array('SITENAME', 'BASEURL', 'announce_url', 'mysql_host', 'mysql_user', 'mysql_pass', 'mysql_db');
+    $validConfig = array('SITENAME', 'BASEURL', 'announce_url', 'mysql_host', 'mysql_user', 'mysql_pass', 'mysql_db', 'meilisearch_host', 'meilisearch_key');
     GetVar($validConfig);
     if (!mysqli_connect($mysql_host, $mysql_user, $mysql_pass)) {
         stdmsg($lang_settings['std_error'], $lang_settings['std_mysql_connect_error'].$lang_settings['std_click']."<a class=\"altlink\" href=\"settings.php\">".$lang_settings['std_here']."</a>".$lang_settings['std_to_go_back']);
@@ -331,6 +331,9 @@ if ($action == 'savesettings_main') {	// save main
     tr($lang_settings['row_mysql_user'], "<input type='text' style=\"width: 300px\" name=mysql_user value='".($BASIC["mysql_user"] ? $BASIC["mysql_user"] : "root")."'> ".$lang_settings['text_mysql_user_note'], 1);
     tr($lang_settings['row_mysql_password'], "<input type='password' style=\"width: 300px\" name=mysql_pass value=''> ".$lang_settings['text_mysql_password_note'], 1);
     tr($lang_settings['row_mysql_database_name'], "<input type='text' style=\"width: 300px\" name=mysql_db value='".($BASIC["mysql_db"] ? $BASIC["mysql_db"] : "nexus")."'> ".$lang_settings['text_mysql_database_name_note'], 1);
+    tr('Meilisearch 地址', "<input type='text' style='width: 300px' name='meilisearch_host' value='" . ($BASIC['meilisearch_host'] ?: 'http://localhost:7700') . "'>", 1);
+    tr('Meilisearch 密钥', "<input type='text' style='width: 300px' name='meilisearch_key' value='" . ($BASIC['meilisearch_key'] ?: '') . "'>", 1);
+
     tr($lang_settings['row_save_settings'], "<input type='submit' name='save' value='".$lang_settings['submit_save_settings']."'>", 1);
     print("</form>");
 } elseif ($action == 'attachmentsettings') {	// basic settings

--- a/takeedit.php
+++ b/takeedit.php
@@ -176,6 +176,12 @@ if (get_user_class()>=$torrentmanage_class && $CURUSER['picker'] == 'yes') {
 }
 \NexusPHP\Components\Database::query("UPDATE torrents SET " . join(",", $updateset) . " WHERE id = $id") or sqlerr(__FILE__, __LINE__);
 
+global $copy_keys;
+
+$query = \NexusPHP\Components\Database::one("SELECT `" . implode('`, `',$copy_keys) . "` FROM torrents WHERE id = $id");
+$torrent_index =\NexusPHP\Components\Meili::getMeiliSearch()->index('torrents');
+$torrent_index->addDocuments(convert_torrent_mysql2meili($query));
+
 if ($CURUSER["id"] == $row["owner"]) {
     if ($row["anonymous"]=='yes') {
         write_log("Torrent $id ($name) was edited by Anonymous" . $pick_info . $place_info);

--- a/takeupload.php
+++ b/takeupload.php
@@ -279,9 +279,16 @@ $id = \NexusPHP\Components\Database::insert_id();
 
 
 $fileTreeJson = $dict->getFileTree();
-\NexusPHP\Components\Database::query("INSERT INTO files (torrent, files) VALUES ($id, " . sqlesc(json_encode($fileTreeJson)) . ")");
+\NexusPHP\Components\Database::query("INSERT INTO files (torrent, files) VALUES ($id, " . \NexusPHP\Components\Database::escape(json_encode($fileTreeJson)) . ")");
 
 $dict->dump("$torrent_dir/$id.torrent");
+
+global $copy_keys;
+
+$query = \NexusPHP\Components\Database::one("SELECT `" . implode('`, `',$copy_keys) . "` FROM torrents WHERE id = $id");
+$torrent_index =\NexusPHP\Components\Meili::getMeiliSearch()->index('torrents');
+$torrent_index->addDocuments(convert_torrent_mysql2meili($query));
+
 
 //===add karma
 KPS("+", $uploadtorrent_bonus, $CURUSER["id"]);
@@ -296,7 +303,7 @@ if ($is_offer) {
 
     while ($row = mysqli_fetch_assoc($res)) {
         $pn_msg = $lang_takeupload_target[get_user_lang($row["userid"])]['msg_offer_you_voted'].$torrent.$lang_takeupload_target[get_user_lang($row["userid"])]['msg_was_uploaded_by']. $CURUSER["username"] .$lang_takeupload_target[get_user_lang($row["userid"])]['msg_you_can_download'] ."[url=" . get_protocol_prefix() . "$BASEURL/details.php?id=$id&hit=1]".$lang_takeupload_target[get_user_lang($row["userid"])]['msg_here']."[/url]";
-        
+
         //=== use this if you DO have subject in your PMs
         $subject = $lang_takeupload_target[get_user_lang($row["userid"])]['msg_offer'].$torrent.$lang_takeupload_target[get_user_lang($row["userid"])]['msg_was_just_uploaded'];
         //=== use this if you DO NOT have subject in your PMs


### PR DESCRIPTION
FULL READ: [NexusPHP优化(4) Torrent表拆分及独立搜索引擎](https://blog.rhilip.info/archives/1275/)

----

在很久很久以前，就有位sysop和我说到：”NexusPHP的压力，六成在种子搜索，四成在Tracker“，我记得ta还和我说过：”NexusPHP的torrents表是张很热很热的表“（也可能是另一站的sysop），于是ta把他们站的搜索引擎切换到了[Xunsearch](http://www.xunsearch.com/)上，果然没有再出现过压力过大的问题。

> 对上面两句话我的粗浅认知：
> 1. tracker在每次seeder, leechers, time_completed 变动时都会更新torrents表，更新很频繁
> 1. 种子搜索使用的是 MySQL 的 `LIKE %...%` 语句，特别是关键词多的时候，如搜索 `I Love Flowers` 会被最终拼成 `WHERE (name LIKE "%Love%" or small_descr LIKE "%Love") and (name LIKE "%Flowers%" or small_descr LIKE "%Flowers%")`。但MySQL的该语句不能走索引（走全文索引的是 `MATCH AGAINST`），所以会触发全表扫描

所以我也信了ta的话，在我站频繁出现5xx错误后，我同样把优化的方向改为了 从Mysql的 `LIKE %...%` 语句中切换到更加专业的全文搜索引擎中。结果很顺利，站点又恢复了之前的流畅。

> 注：
>
> 1. 本pr不仅仅有全文搜索引擎的替换说明，还涉及对NPHP他那屎山一般的 `torrents.php` 实现进行优化；因此，全部实现示例会拆成多个commit+1个整体pr来尽可能展示本站的更新。
> 2. 本pr在行文以及对应commit中的实现与OurBits站点的实现并不一致，仅作思路展示。
> 3. 本pr并不一定保证运行，一些隐藏的地方并没有考虑到，还请理解。